### PR TITLE
Do not override cache map when initializing with an empty dict

### DIFF
--- a/aiodataloader.py
+++ b/aiodataloader.py
@@ -17,12 +17,12 @@ class DataLoader(object):
     cache = True
 
     def __init__(self, batch_load_fn=None, batch=None, max_batch_size=None, cache=None, get_cache_key=None, cache_map=None, loop=None):
-        
+
         self.loop = loop or get_event_loop()
 
         if batch_load_fn is not None:
             self.batch_load_fn = batch_load_fn
-        
+
         assert iscoroutinefunction(self.batch_load_fn), "batch_load_fn must be coroutine. Received: {}".format(self.batch_load_fn)
 
         if not callable(self.batch_load_fn):
@@ -43,12 +43,12 @@ class DataLoader(object):
         if get_cache_key is not None:
             self.get_cache_key = get_cache_key
 
-        self._cache = cache_map or {}
+        self._cache = cache_map if cache_map is not None else {}
         self._queue = []  # type: List[Loader]
 
     def get_cache_key(self, key):  # type: ignore
         return key
-    
+
     def load(self, key=None):
         '''
         Loads a key, returning a `Future` for the value represented by that key.
@@ -207,7 +207,7 @@ async def dispatch_queue_batch(loader, queue):
                 'not return a Coroutine: {}.'
             ).format(batch_future))
         )
-    
+
     try:
         values = await batch_future
         if not isinstance(values, Iterable):
@@ -216,7 +216,7 @@ async def dispatch_queue_batch(loader, queue):
                 'Iterable<key> and returns Future<Iterable<value>>, but the function did '
                 'not return a Future of a Iterable: {}.'
             ).format(values))
-        
+
         values = list(values)
         if len(values) != len(keys):
             raise TypeError((


### PR DESCRIPTION
Hi,
I found this issue while setting up a cache shared between multiple dataloaders.
My dataloader manager intializes an empty dict then passes it to multiple dataloders, but the cache seemed to never be properly shared.

```python
shared_cache = {}
user_by_id_loader = DataLoader(user_by_id_batch_fn, cache_map=shared_cache)
username_loader = DataLoader(username_batch_fn, cache_map=shared_cache)
```
(expanding on the pattern described here, with a cache management feature shared between multiple dataloaders, and a shared cache: https://github.com/syrusakbary/aiodataloader#loading-by-alternative-keys )

The following line caused the dataloader to override the shared cache with an empty dict in its own local scope, because an empty dict is treated as a false-y by python:
```python
self._cache = cache_map or {}
```

With the proposed fix, this scenario won't fail.

Thanks!

( @abusi, please check this )