### PR TITLE
Fix `print` related typos in the README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,8 @@ user2 = await user2_future
 user1_invitedby = user_loader.load(user1.invited_by_id)
 user2_invitedby = user_loader.load(user2.invited_by_id)
 
-
-print "User 1 was invited by", await user1_invitedby
-print "User 2 was invited by", await user2_invitedby
+print("User 1 was invited by", await user1_invitedby)
+print("User 2 was invited by", await user2_invitedby)
 ```
 
 A naive application may have issued four round-trips to a backend for the

--- a/README.rst
+++ b/README.rst
@@ -80,9 +80,8 @@ all requested keys.
     user1_invitedby = user_loader.load(user1.invited_by_id)
     user2_invitedby = user_loader.load(user2.invited_by_id)
 
-
-    print "User 1 was invited by", await user1_invitedby
-    print "User 2 was invited by", await user2_invitedby
+    print("User 1 was invited by", await user1_invitedby)
+    print("User 2 was invited by", await user2_invitedby)
 
 A naive application may have issued four round-trips to a backend for
 the required information, but with DataLoader this application will make


### PR DESCRIPTION
Since this package is Python 3.5+ only, the examples inside the README
files should reflect that; before this change, they where using the
statement form of `print` (which is Python 2.x only) instead of the
function form.