### PR TITLE
Fix use of deprecated abstract collections import

### DIFF
--- a/aiodataloader.py
+++ b/aiodataloader.py
@@ -1,5 +1,6 @@
 from asyncio import gather, ensure_future, get_event_loop, iscoroutine, iscoroutinefunction
-from collections import Iterable, Sized, namedtuple
+from collections import namedtuple
+from collections.abc import Iterable, Sized
 from functools import partial
 
 from typing import List  # flake8: noqa

--- a/aiodataloader.py
+++ b/aiodataloader.py
@@ -1,6 +1,6 @@
 from asyncio import gather, ensure_future, get_event_loop, iscoroutine, iscoroutinefunction
 from collections import namedtuple
-from collections.abc import Iterable, Sized
+from collections.abc import Iterable
 from functools import partial
 
 from typing import List  # flake8: noqa


### PR DESCRIPTION
Abstract collections have been moved to module `collections.abc` since Python 3.3 (using aiodataloader triggers a deprecation warning on abstract collections import from `collections`).
Since aiodataloader targets Python 3.5+, this has no impact.

This should be merged and published to PyPI before Python 3.8 hits, since compatibility import from the `collections` module will be removed.