### PR TITLE
Fixed DataLoader failing for partial load functions

### DIFF
--- a/aiodataloader.py
+++ b/aiodataloader.py
@@ -9,6 +9,9 @@ __version__ = '0.1.2'
 
 Loader = namedtuple('Loader', 'key,future')
 
+def iscoroutinefunctionorpartial(fn):
+    return iscoroutinefunction(fn.func if isinstance(fn, partial) else fn)
+
 
 class DataLoader(object):
 
@@ -23,7 +26,7 @@ class DataLoader(object):
         if batch_load_fn is not None:
             self.batch_load_fn = batch_load_fn
 
-        assert iscoroutinefunction(self.batch_load_fn), "batch_load_fn must be coroutine. Received: {}".format(self.batch_load_fn)
+        assert iscoroutinefunctionorpartial(self.batch_load_fn), "batch_load_fn must be coroutine. Received: {}".format(self.batch_load_fn)
 
         if not callable(self.batch_load_fn):
             raise TypeError((

--- a/aiodataloader.py
+++ b/aiodataloader.py
@@ -1,5 +1,5 @@
 from asyncio import gather, ensure_future, get_event_loop, iscoroutine, iscoroutinefunction
-from collections import Iterable, Sized, namedtuple
+from collections import Iterable, namedtuple
 from functools import partial
 
 from typing import List  # flake8: noqa
@@ -8,6 +8,7 @@ from typing import List  # flake8: noqa
 __version__ = '0.1.2'
 
 Loader = namedtuple('Loader', 'key,future')
+
 
 def iscoroutinefunctionorpartial(fn):
     return iscoroutinefunction(fn.func if isinstance(fn, partial) else fn)
@@ -19,14 +20,16 @@ class DataLoader(object):
     max_batch_size = None  # type: int
     cache = True
 
-    def __init__(self, batch_load_fn=None, batch=None, max_batch_size=None, cache=None, get_cache_key=None, cache_map=None, loop=None):
+    def __init__(self, batch_load_fn=None, batch=None, max_batch_size=None,
+                 cache=None, get_cache_key=None, cache_map=None, loop=None):
 
         self.loop = loop or get_event_loop()
 
         if batch_load_fn is not None:
             self.batch_load_fn = batch_load_fn
 
-        assert iscoroutinefunctionorpartial(self.batch_load_fn), "batch_load_fn must be coroutine. Received: {}".format(self.batch_load_fn)
+        assert iscoroutinefunctionorpartial(self.batch_load_fn), "batch_load_fn must be coroutine. Received: {}".format(
+            self.batch_load_fn)
 
         if not callable(self.batch_load_fn):
             raise TypeError((

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_version(filename):
 version = get_version('aiodataloader.py')
 
 tests_require = [
-    'pytest>=2.7.3', 'pytest-cov', 'coveralls', 'mock', 'pytest-asyncio'
+    'pytest>=3.6', 'pytest-cov', 'coveralls', 'mock', 'pytest-asyncio'
 ]
 
 setup(


### PR DESCRIPTION
This change ensures `DataLoader` does  not fail when passed a partial wrapped coroutine.