### PR TITLE
Cache cleared without creating default instance

### DIFF
--- a/aiodataloader.py
+++ b/aiodataloader.py
@@ -129,7 +129,7 @@ class DataLoader(object):
         invalidations across this particular `DataLoader`. Returns itself for
         method chaining.
         '''
-        self._cache = {}
+        self._cache.clear()
         return self
 
     def prime(self, key, value):


### PR DESCRIPTION
It is possible to pass custom implementation of the cache to the constructor.
However, when the cache is cleared, it is always instantiated with default implementation.