### PR TITLE
Resolve deprecation warning for Python 3.9

### DIFF
--- a/aiodataloader.py
+++ b/aiodataloader.py
@@ -1,5 +1,6 @@
 from asyncio import gather, ensure_future, get_event_loop, iscoroutine, iscoroutinefunction
-from collections import Iterable, namedtuple
+from collections import namedtuple
+from collections.abc import Iterable
 from functools import partial
 
 from typing import List  # flake8: noqa


### PR DESCRIPTION
Python 3.8 creates warnings that fail on stringent testing:

`aiodataloader.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Iterable, namedtuple

-- Docs: https://docs.pytest.org/en/latest/warnings.html`
