### PR TITLE
Change typing of batch_load_fn to support subclass overriding

### DIFF
--- a/aiodataloader.py
+++ b/aiodataloader.py
@@ -19,11 +19,6 @@ from typing import (
     Union,
 )
 
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
-
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
 else:
@@ -45,11 +40,6 @@ def iscoroutinefunctionorpartial(
     return iscoroutinefunction(fn.func if isinstance(fn, partial) else fn)
 
 
-class BatchLoadFnProto(Protocol[KeyT, ReturnT]):
-    async def __call__(self, keys: List[KeyT]) -> List[ReturnT]:
-        ...
-
-
 Loader = namedtuple('Loader', 'key,future')
 
 
@@ -61,7 +51,7 @@ class DataLoader(Generic[KeyT, ReturnT]):
 
     def __init__(
         self,
-        batch_load_fn: Optional[BatchLoadFnProto[KeyT, ReturnT]] = None,
+        batch_load_fn: Optional[Callable[[List[KeyT]], Coroutine[Any, Any, List[ReturnT]]]] = None,
         batch: Optional[bool] = None,
         max_batch_size: Optional[int] = None,
         cache: Optional[bool] = None,


### PR DESCRIPTION
Using a `Protocol` to type `batch_load_fn` does not play well with the documented pattern of overriding the method in a subclass.

For instance:
```python
class TestDataLoader(DataLoader[str, str]):

    async def batch_load_fn(self, keys: list[str]) -> list[str]:
        return [key for key in keys]
```

This causes mypy to complain `Signature of "batch_load_fn" incompatible with supertype "DataLoader"`.

Fixing by typing `batch_load_fn` as `Callable[[List[KeyT]], Coroutine[Any, Any, List[ReturnT]]]`, which also avoids the conditional import of `Protocol`.