### PR TITLE
Expand linting to include formatting and import order

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+application_import_names = aiodataloader
+exclude = .git,.mypy_cache,.pytest_cache,.tox,.venv,__pycache__,build,dist,docs
+ignore = E203
+import_order_style = smarkets
+max-line-length = 88

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: |
@@ -24,5 +24,6 @@ jobs:
         pip install -e .[lint]
     - name: Run code quality tests
       run: |
+        black --check .
         flake8
         mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.9']
 
     steps:
       - uses: actions/checkout@v3
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+target-version = ["py36", "py37", "py38", "py39", "py310", "py311"]
+
+[tool.isort]
+force_single_line = false
+known_first_party = "aiodataloader"
+order_by_type = false
+profile = "black"
+
+[tool.mypy]
+files = ["aiodataloader/**/*.py", "setup.py", "test_aiodataloader.py"]
+follow_imports = "silent"
+ignore_missing_imports = true
+strict = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[flake8]
-exclude = test_*,scripts,setup.py,docs
-max-line-length = 120
-
-[mypy]
-files = aiodataloader/*, test_aiodataloader.py
-follow_imports = silent
-ignore_missing_imports = True
-strict = True

--- a/setup.py
+++ b/setup.py
@@ -1,57 +1,54 @@
-import os
-import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
-def get_version(filename):
+def get_version(filename: str) -> str:
     import os
     import re
 
     here = os.path.dirname(os.path.abspath(__file__))
     with open(os.path.join(here, filename)) as f:
         version_file = f.read()
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
 
-version = get_version('aiodataloader/__init__.py')
+version = get_version("aiodataloader/__init__.py")
 
-tests_require = [
-    'pytest>=3.6', 'pytest-cov', 'coveralls', 'mock', 'pytest-asyncio'
-]
+tests_require = ["pytest>=3.6", "pytest-cov", "coveralls", "mock", "pytest-asyncio"]
 
 setup(
-    name='aiodataloader',
+    name="aiodataloader",
     version=version,
-    description='Asyncio DataLoader implementation for Python',
-    long_description=open('README.md').read(),
+    description="Asyncio DataLoader implementation for Python",
+    long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    url='https://github.com/syrusakbary/aiodataloader',
-    download_url='https://github.com/syrusakbary/aiodataloader/releases',
-    author='Syrus Akbary',
-    author_email='me@syrusakbary.com',
-    license='MIT',
+    url="https://github.com/syrusakbary/aiodataloader",
+    download_url="https://github.com/syrusakbary/aiodataloader/releases",
+    author="Syrus Akbary",
+    author_email="me@syrusakbary.com",
+    license="MIT",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Libraries',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'License :: OSI Approved :: MIT License',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "License :: OSI Approved :: MIT License",
     ],
-    keywords='concurrent future deferred aiodataloader',
-    py_modules=['aiodataloader'],
-    python_requires='>=3.6',
+    keywords="concurrent future deferred aiodataloader",
+    py_modules=["aiodataloader"],
+    python_requires=">=3.6",
     extras_require={
-        'lint': ['flake8', 'mypy'],
-        'test': tests_require,
+        "lint": ["black", "flake8", "flake8-import-order", "mypy"],
+        "test": tests_require,
     },
-    install_requires=["typing_extensions>=4.3.0"],
-    tests_require=tests_require, )
+    install_requires=["typing_extensions>=4.1.1"],
+    tests_require=tests_require,
+)

--- a/test_aiodataloader.py
+++ b/test_aiodataloader.py
@@ -1,12 +1,12 @@
-import pytest
 from asyncio import gather
 from functools import partial
-from pytest import raises
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, TypeVar, Union
+
+import pytest
+
 from aiodataloader import DataLoader
 
 pytestmark = pytest.mark.asyncio
-
 
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
@@ -15,8 +15,13 @@ T2 = TypeVar("T2")
 async def do_test() -> bool:
     return True
 
+
 def id_loader(
-    *, resolve: Optional[Callable[[List[T1]], Coroutine[Any, Any, Union[List[T1], List[T2]]]]] = None, **dl_kwargs: Any
+    *,
+    resolve: Optional[
+        Callable[[List[T1]], Coroutine[Any, Any, Union[List[T1], List[T2]]]]
+    ] = None,
+    **dl_kwargs: Any,
 ) -> Tuple[DataLoader[T1, Union[T1, T2]], List[List[T1]]]:
     load_calls: List[List[T1]] = []
 
@@ -55,7 +60,7 @@ async def test_can_build_a_data_loader_from_a_partial() -> None:
     promise1 = identity_loader.load(1)
 
     value1 = await promise1
-    assert value1 == 'one'
+    assert value1 == "one"
 
 
 async def test_supports_loading_multiple_keys_in_one_call() -> None:
@@ -93,7 +98,9 @@ async def test_batches_multiple_requests() -> None:
 
 
 async def test_batches_multiple_requests_with_max_batch_sizes() -> None:
-    loader_result: Tuple[DataLoader[int, int], List[List[int]]] = id_loader(max_batch_size=2)
+    loader_result: Tuple[DataLoader[int, int], List[List[int]]] = id_loader(
+        max_batch_size=2
+    )
     identity_loader, load_calls = loader_result
 
     promise1 = identity_loader.load(1)
@@ -133,150 +140,129 @@ async def test_caches_repeated_requests() -> None:
     loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader()
     identity_loader, load_calls = loader_result
 
-    a, b = await gather(
-        identity_loader.load('A'),
-        identity_loader.load('B')
-    )
+    a, b = await gather(identity_loader.load("A"), identity_loader.load("B"))
 
-    assert a == 'A'
-    assert b == 'B'
+    assert a == "A"
+    assert b == "B"
 
-    assert load_calls == [['A', 'B']]
+    assert load_calls == [["A", "B"]]
 
-    a2, c = await gather(
-        identity_loader.load('A'),
-        identity_loader.load('C')
-    )
+    a2, c = await gather(identity_loader.load("A"), identity_loader.load("C"))
 
-    assert a2 == 'A'
-    assert c == 'C'
+    assert a2 == "A"
+    assert c == "C"
 
-    assert load_calls == [['A', 'B'], ['C']]
+    assert load_calls == [["A", "B"], ["C"]]
 
     a3, b2, c2 = await gather(
-        identity_loader.load('A'),
-        identity_loader.load('B'),
-        identity_loader.load('C')
+        identity_loader.load("A"), identity_loader.load("B"), identity_loader.load("C")
     )
 
-    assert a3 == 'A'
-    assert b2 == 'B'
-    assert c2 == 'C'
+    assert a3 == "A"
+    assert b2 == "B"
+    assert c2 == "C"
 
-    assert load_calls == [['A', 'B'], ['C']]
+    assert load_calls == [["A", "B"], ["C"]]
 
 
 async def test_clears_single_value_in_loader() -> None:
     loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader()
     identity_loader, load_calls = loader_result
 
-    a, b = await gather(
-        identity_loader.load('A'),
-        identity_loader.load('B')
-    )
+    a, b = await gather(identity_loader.load("A"), identity_loader.load("B"))
 
-    assert a == 'A'
-    assert b == 'B'
+    assert a == "A"
+    assert b == "B"
 
-    assert load_calls == [['A', 'B']]
+    assert load_calls == [["A", "B"]]
 
-    identity_loader.clear('A')
+    identity_loader.clear("A")
 
-    a2, b2 = await gather(
-        identity_loader.load('A'),
-        identity_loader.load('B')
-    )
+    a2, b2 = await gather(identity_loader.load("A"), identity_loader.load("B"))
 
-    assert a2 == 'A'
-    assert b2 == 'B'
+    assert a2 == "A"
+    assert b2 == "B"
 
-    assert load_calls == [['A', 'B'], ['A']]
+    assert load_calls == [["A", "B"], ["A"]]
 
 
 async def test_clears_all_values_in_loader() -> None:
     loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader()
     identity_loader, load_calls = loader_result
 
-    a, b = await gather(
-        identity_loader.load('A'),
-        identity_loader.load('B')
-    )
+    a, b = await gather(identity_loader.load("A"), identity_loader.load("B"))
 
-    assert a == 'A'
-    assert b == 'B'
+    assert a == "A"
+    assert b == "B"
 
-    assert load_calls == [['A', 'B']]
+    assert load_calls == [["A", "B"]]
 
     identity_loader.clear_all()
 
-    a2, b2 = await gather(
-        identity_loader.load('A'),
-        identity_loader.load('B')
-    )
+    a2, b2 = await gather(identity_loader.load("A"), identity_loader.load("B"))
 
-    assert a2 == 'A'
-    assert b2 == 'B'
+    assert a2 == "A"
+    assert b2 == "B"
 
-    assert load_calls == [['A', 'B'], ['A', 'B']]
+    assert load_calls == [["A", "B"], ["A", "B"]]
 
 
 async def test_allows_priming_the_cache() -> None:
     loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader()
     identity_loader, load_calls = loader_result
 
-    identity_loader.prime('A', 'A')
+    identity_loader.prime("A", "A")
 
-    a, b = await gather(
-        identity_loader.load('A'),
-        identity_loader.load('B')
-    )
+    a, b = await gather(identity_loader.load("A"), identity_loader.load("B"))
 
-    assert a == 'A'
-    assert b == 'B'
+    assert a == "A"
+    assert b == "B"
 
-    assert load_calls == [['B']]
+    assert load_calls == [["B"]]
 
 
 async def test_does_not_prime_keys_that_already_exist() -> None:
     loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader()
     identity_loader, load_calls = loader_result
 
-    identity_loader.prime('A', 'X')
+    identity_loader.prime("A", "X")
 
-    a1 = await identity_loader.load('A')
-    b1 = await identity_loader.load('B')
+    a1 = await identity_loader.load("A")
+    b1 = await identity_loader.load("B")
 
-    assert a1 == 'X'
-    assert b1 == 'B'
+    assert a1 == "X"
+    assert b1 == "B"
 
-    identity_loader.prime('A', 'Y')
-    identity_loader.prime('B', 'Y')
+    identity_loader.prime("A", "Y")
+    identity_loader.prime("B", "Y")
 
-    a2 = await identity_loader.load('A')
-    b2 = await identity_loader.load('B')
+    a2 = await identity_loader.load("A")
+    b2 = await identity_loader.load("B")
 
-    assert a2 == 'X'
-    assert b2 == 'B'
+    assert a2 == "X"
+    assert b2 == "B"
 
-    assert load_calls == [['B']]
+    assert load_calls == [["B"]]
 
 
 # # Represents Errors
 
+
 async def test_resolves_to_error_to_indicate_failure() -> None:
     async def resolve(keys: List[int]) -> List[int]:
         mapped_keys = [
-            key if key % 2 == 0 else Exception("Odd: {}".format(key))
-            for key in keys
+            key if key % 2 == 0 else Exception("Odd: {}".format(key)) for key in keys
         ]
         # ignored because Exceptions are not expected for a batch_load_fn
         # but we are testing unexpected behavior
-        return mapped_keys # type: ignore
+        return mapped_keys  # type: ignore
 
-    loader_result: Tuple[DataLoader[int, int], List[List[int]]] = id_loader(resolve=resolve)
+    loader_result: Tuple[DataLoader[int, int], List[List[int]]] = id_loader(
+        resolve=resolve
+    )
     even_loader, load_calls = loader_result
 
-    with raises(Exception) as exc_info:
+    with pytest.raises(Exception) as exc_info:
         await even_loader.load(1)
 
     assert str(exc_info.value) == "Odd: 1"
@@ -289,17 +275,19 @@ async def test_resolves_to_error_to_indicate_failure() -> None:
 async def test_can_represent_failures_and_successes_simultaneously() -> None:
     async def resolve(keys: List[int]) -> List[int]:
         mapped_keys = [
-            key if key % 2 == 0 else Exception("Odd: {}".format(key))
-            for key in keys
+            key if key % 2 == 0 else Exception("Odd: {}".format(key)) for key in keys
         ]
-        return mapped_keys # type: ignore
-    loader_result: Tuple[DataLoader[int, int], List[List[int]]] = id_loader(resolve=resolve)
+        return mapped_keys  # type: ignore
+
+    loader_result: Tuple[DataLoader[int, int], List[List[int]]] = id_loader(
+        resolve=resolve
+    )
     even_loader, load_calls = loader_result
 
     promise1 = even_loader.load(1)
     promise2 = even_loader.load(2)
 
-    with raises(Exception) as exc_info:
+    with pytest.raises(Exception) as exc_info:
         await promise1
 
     assert str(exc_info.value) == "Odd: 1"
@@ -310,21 +298,20 @@ async def test_can_represent_failures_and_successes_simultaneously() -> None:
 
 async def test_caches_failed_fetches() -> None:
     async def resolve(keys: List[int]) -> List[int]:
-        mapped_keys = [
-            Exception("Error: {}".format(key))
-            for key in keys
-        ]
+        mapped_keys = [Exception("Error: {}".format(key)) for key in keys]
         return mapped_keys  # type: ignore
 
-    loader_result: Tuple[DataLoader[int, int], List[List[int]]] = id_loader(resolve=resolve)
+    loader_result: Tuple[DataLoader[int, int], List[List[int]]] = id_loader(
+        resolve=resolve
+    )
     error_loader, load_calls = loader_result
 
-    with raises(Exception) as exc_info:
+    with pytest.raises(Exception) as exc_info:
         await error_loader.load(1)
 
     assert str(exc_info.value) == "Error: 1"
 
-    with raises(Exception) as exc_info:
+    with pytest.raises(Exception) as exc_info:
         await error_loader.load(1)
 
     assert str(exc_info.value) == "Error: 1"
@@ -338,81 +325,90 @@ async def test_caches_failed_fetches_2() -> None:
 
     identity_loader.prime(1, Exception("Error: 1"))  # type: ignore
 
-    with raises(Exception) as exc_info:
+    with pytest.raises(Exception):
         await identity_loader.load(1)
 
     assert load_calls == []
 
-# It is resilient to job queue ordering
 
+# It is resilient to job queue ordering
 async def test_batches_loads_occuring_within_promises() -> None:
     loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader()
     identity_loader, load_calls = loader_result
+
     async def load_b_1() -> str:
         return await load_b_2()
 
     async def load_b_2() -> str:
-        return await identity_loader.load('B')
+        return await identity_loader.load("B")
 
-    values = list(await gather(
-        identity_loader.load('A'),
-        load_b_1()
-    ))
+    values = list(await gather(identity_loader.load("A"), load_b_1()))
 
-    assert values == ['A', 'B']
+    assert values == ["A", "B"]
 
-    assert load_calls == [['A', 'B']]
+    assert load_calls == [["A", "B"]]
 
 
 async def test_catches_error_if_loader_resolver_fails() -> None:
     exc = Exception("AOH!")
+
     def do_resolve(x: List[Any]) -> Coroutine[Any, Any, List[Any]]:
         raise exc
 
-    loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader(resolve=do_resolve)
+    loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader(
+        resolve=do_resolve
+    )
     a_loader, a_load_calls = loader_result
 
-    with raises(Exception) as exc_info:
-        await a_loader.load('A1')
+    with pytest.raises(Exception) as exc_info:
+        await a_loader.load("A1")
 
     assert exc_info.value == exc
 
 
 async def test_can_call_a_loader_from_a_loader() -> None:
-    deep_loader_result: Tuple[DataLoader[Tuple[str, ...], Tuple[str, ...]], List[List[Tuple[str, ...]]]] = id_loader()
+    deep_loader_result: Tuple[
+        DataLoader[Tuple[str, ...], Tuple[str, ...]], List[List[Tuple[str, ...]]]
+    ] = id_loader()
     deep_loader, deep_load_calls = deep_loader_result
 
     async def do_resolve(keys: List[str]) -> List[str]:
         return list(await deep_loader.load(tuple(keys)))
 
-    a_loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader(resolve=do_resolve)
+    a_loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader(
+        resolve=do_resolve
+    )
     a_loader, a_load_calls = a_loader_result
 
-    b_loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader(resolve=do_resolve)
+    b_loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader(
+        resolve=do_resolve
+    )
     b_loader, b_load_calls = b_loader_result
 
     a1, b1, a2, b2 = await gather(
-        a_loader.load('A1'),
-        b_loader.load('B1'),
-        a_loader.load('A2'),
-        b_loader.load('B2')
+        a_loader.load("A1"),
+        b_loader.load("B1"),
+        a_loader.load("A2"),
+        b_loader.load("B2"),
     )
 
-    assert a1 == 'A1'
-    assert b1 == 'B1'
-    assert a2 == 'A2'
-    assert b2 == 'B2'
+    assert a1 == "A1"
+    assert b1 == "B1"
+    assert a2 == "A2"
+    assert b2 == "B2"
 
-    assert a_load_calls == [['A1', 'A2']]
-    assert b_load_calls == [['B1', 'B2']]
-    assert deep_load_calls == [[('A1', 'A2'), ('B1', 'B2')]]
+    assert a_load_calls == [["A1", "A2"]]
+    assert b_load_calls == [["B1", "B2"]]
+    assert deep_load_calls == [[("A1", "A2"), ("B1", "B2")]]
 
 
 async def test_dataloader_clear_with_missing_key_works() -> None:
     async def do_resolve(x: List[Any]) -> List[Any]:
         return x
 
-    a_loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader(resolve=do_resolve)
+    a_loader_result: Tuple[DataLoader[str, str], List[List[str]]] = id_loader(
+        resolve=do_resolve
+    )
     a_loader, a_load_calls = a_loader_result
 
-    assert a_loader.clear('A1') == a_loader
+    assert a_loader.clear("A1") == a_loader


### PR DESCRIPTION
Expands linting to enforce formatting with `black`, and checks for correct import order.

Also adding Python 3.11 as supported, and using it for linting workflows.