### PR TITLE
Deprecate support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.9']
 
     steps:
       - uses: actions/checkout@v3

--- a/aiodataloader/__init__.py
+++ b/aiodataloader/__init__.py
@@ -48,7 +48,6 @@ Loader = namedtuple("Loader", "key,future")
 
 
 class DataLoader(Generic[KeyT, ReturnT]):
-
     batch: bool = True
     max_batch_size: Optional[int] = None
     cache: Optional[bool] = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,12 @@ dynamic = ["version"]
 authors = [{ name="Syrus Akbary", email="me@syrusakbary.com" }]
 description = "Asyncio DataLoader implementation for Python"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -33,7 +32,7 @@ test = ["pytest>=3.6", "pytest-cov", "coveralls", "mock", "pytest-asyncio"]
 "Homepage" = "https://github.com/syrusakbary/aiodataloader"
 
 [tool.black]
-target-version = ["py36", "py37", "py38", "py39", "py310", "py311"]
+target-version = ["py37", "py38", "py39", "py310", "py311"]
 
 [tool.hatch.version]
 path = "aiodataloader/__init__.py"


### PR DESCRIPTION
Python 3.6 is EOL, and no longer supported for tests in GitHub workflows.  Deprecating support for it here, in preparation for a 0.4.0 release.