### PR TITLE
Make key arg of load() required

### DIFF
--- a/aiodataloader/__init__.py
+++ b/aiodataloader/__init__.py
@@ -100,7 +100,7 @@ class DataLoader(Generic[KeyT, ReturnT]):
         self._cache = cache_map if cache_map is not None else {}
         self._queue: List[Loader] = []
 
-    def load(self, key: Optional[KeyT] = None) -> "Future[ReturnT]":
+    def load(self, key: KeyT) -> "Future[ReturnT]":
         """
         Loads a key, returning a `Future` for the value represented by that key.
         """

--- a/test_aiodataloader.py
+++ b/test_aiodataloader.py
@@ -412,3 +412,21 @@ async def test_dataloader_clear_with_missing_key_works() -> None:
     a_loader, a_load_calls = a_loader_result
 
     assert a_loader.clear("A1") == a_loader
+
+
+async def test_load_no_key() -> None:
+    async def call_fn(keys: List[int]) -> List[int]:
+        return keys
+
+    identity_loader = DataLoader(call_fn)
+    with pytest.raises(TypeError):
+        identity_loader.load()  # type: ignore
+
+
+async def test_load_none() -> None:
+    async def call_fn(keys: List[int]) -> List[int]:
+        return keys
+
+    identity_loader = DataLoader(call_fn)
+    with pytest.raises(TypeError):
+        identity_loader.load(None)  # type: ignore


### PR DESCRIPTION
The `DataLoader.load()` interface permits passing `None` or omitting the `key` argument, although both of these are guaranteed to raise a TypeError.  This will not be caught by linting but will crash at runtime, which is really bad.  Moreover, this is in conflict with the [JavaScript reference implementation](https://github.com/graphql/dataloader/blob/main/src/index.js#L74).

Since omitting a required argument also raises a `TypeError` in Python, this behavior can be corrected without breaking backwards compatibility.