### PR TITLE
Fix incorrectly setting cancelled futures

### DIFF
--- a/test_aiodataloader.py
+++ b/test_aiodataloader.py
@@ -298,9 +298,10 @@ async def test_can_represent_failures_and_successes_simultaneously() -> None:
 
 
 async def test_does_not_attempt_to_set_cancelled_future() -> None:
+    exception_handler = Mock()
     loop = get_running_loop()
-    loop.set_exception_handler(Mock())
-    fut = Future()
+    loop.set_exception_handler(exception_handler)
+    fut: Future[None] = Future()
 
     async def call_fn(keys: List[int]) -> List[int]:
         await fut
@@ -319,7 +320,6 @@ async def test_does_not_attempt_to_set_cancelled_future() -> None:
     # Give time to the event loop to call the exception handler if needed
     await sleep(0.001)
 
-    exception_handler = loop.get_exception_handler()
     exception_handler.assert_not_called()
 
 


### PR DESCRIPTION
Hi there,

I'm running `aiodataloader` in production, not in a GraphQL context, but in a concurrent message consumer. Some messages consumed in the same event loop iteration may refer to the same data, and an uncached `DataLoader` helps with the IO load.

When the connection to the message broker drops, the current message handling tasks will get cancelled.

This leads to this typical log message:
```
ERROR    asyncio:base_events.py:1820 Task exception was never retrieved
future: <Task finished name='Task-65' coro=<dispatch_queue_batch() done, defined at /home/loris/Code/aiodataloader-next/aiodataloader/__init__.py:247> exception=InvalidStateError('invalid state')>
Traceback (most recent call last):
  File "/home/loris/Code/aiodataloader-next/aiodataloader/__init__.py", line 300, in dispatch_queue_batch
    ql.future.set_result(value)
asyncio.exceptions.InvalidStateError: invalid state

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/loris/Code/aiodataloader-next/aiodataloader/__init__.py", line 303, in dispatch_queue_batch
    return failed_dispatch(loader, queue, e)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/loris/Code/aiodataloader-next/aiodataloader/__init__.py", line 315, in failed_dispatch
    ql.future.set_exception(error)
asyncio.exceptions.InvalidStateError: invalid state
```

It turns out `aiodataloader` is not checking if an `asyncio.Future` is not already cancelled before attempting to set it, which is against `asyncio` [recommended practice](https://docs.python.org/3/library/asyncio-future.html#asyncio.Future.cancelled).

This PR enforces this check for all `asyncio.Future` set by `aiodataloader`.