### PR TITLE
Update release workflow to use release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-
+    environment: release
     permissions:
       id-token: write
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.13


### PR DESCRIPTION
The release environment does not yet exist, but should be added along with trusted publisher management.