### PR TITLE
Import `iscoroutinefunction()` from the `inspect` module on Python >= 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.13
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.14'
         cache: pip
     - name: Install dependencies
       run: |
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/aiodataloader/__init__.py
+++ b/aiodataloader/__init__.py
@@ -6,7 +6,6 @@ from asyncio import (
     gather,
     get_event_loop,
     iscoroutine,
-    iscoroutinefunction,
 )
 from collections import namedtuple
 from functools import partial
@@ -23,6 +22,11 @@ from typing import (
     TypeVar,
     Union,
 )
+
+if sys.version_info >= (3, 14):
+    from inspect import iscoroutinefunction
+else:
+    from asyncio import iscoroutinefunction
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ test = ["coveralls", "hatch",  "mock", "pytest>=3.6", "pytest-asyncio", "pytest-
 "Homepage" = "https://github.com/syrusakbary/aiodataloader"
 
 [tool.black]
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py37", "py38", "py39", "py310", "py311", "py312", "py313", "py314"]
 
 [tool.hatch.envs.default.scripts]
 lint = "flake8 && black --check . && mypy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
 ]
 keywords = ["concurrent", "future", "deferred", "aiodataloader"]


### PR DESCRIPTION
From Python 3.14 on, importing `iscoroutinefunction()` from the `asyncio` module is deprecated, and will generate a warning. This function will be removed in Python 3.16.
https://docs.python.org/3/deprecations/index.html#pending-removal-in-python-3-16

This conditionally imports `iscoroutinefunction()` from the `inspect` module on Python 3.14 and above, so the project can now safely advertise compatibility with Python 3.14 (and earlier) versions.

Additionally, I've updated the test and release workflows for Python 3.14, is this okay?