### PR TITLE
Change future checks from .cancelled() to .done() before setting future results.

### DIFF
--- a/aiodataloader/__init__.py
+++ b/aiodataloader/__init__.py
@@ -196,7 +196,7 @@ class DataLoader(Generic[KeyT, ReturnT]):
             # Cache a rejected future if the value is an Error, in order to match
             # the behavior of load(key).
             future = self.loop.create_future()
-            if not future.cancelled():
+            if not future.done():
                 if isinstance(value, Exception):
                     future.set_exception(value)
                 else:
@@ -295,7 +295,7 @@ async def dispatch_queue_batch(
         # Step through the values, resolving or rejecting each Future in the
         # loaded queue.
         for ql, value in zip(queue, values):
-            if not ql.future.cancelled():
+            if not ql.future.done():
                 if isinstance(value, Exception):
                     ql.future.set_exception(value)
                 else:
@@ -314,5 +314,5 @@ def failed_dispatch(
     """
     for ql in queue:
         loader.clear(ql.key)
-        if not ql.future.cancelled():
+        if not ql.future.done():
             ql.future.set_exception(error)

--- a/test_aiodataloader.py
+++ b/test_aiodataloader.py
@@ -325,7 +325,7 @@ async def test_does_not_attempt_to_set_cancelled_future() -> None:
 
 async def test_does_not_attempt_to_set_future_with_result() -> None:
     """
-    Test that demonstrates why done() is better than cancelled().    
+    Test that demonstrates why done() is better than cancelled().
     If a future already has a result set (but is not cancelled), checking only
     cancelled() would allow us to try setting it again, causing InvalidStateError.
     Using done() prevents this.

--- a/test_aiodataloader.py
+++ b/test_aiodataloader.py
@@ -325,8 +325,7 @@ async def test_does_not_attempt_to_set_cancelled_future() -> None:
 
 async def test_does_not_attempt_to_set_future_with_result() -> None:
     """
-    Test that demonstrates why done() is better than cancelled().
-    
+    Test that demonstrates why done() is better than cancelled().    
     If a future already has a result set (but is not cancelled), checking only
     cancelled() would allow us to try setting it again, causing InvalidStateError.
     Using done() prevents this.
@@ -363,7 +362,6 @@ async def test_does_not_attempt_to_set_future_with_result() -> None:
 async def test_does_not_attempt_to_set_future_with_exception() -> None:
     """
     Test that demonstrates why done() is better than cancelled().
-    
     If a future already has an exception set (but is not cancelled), checking only
     cancelled() would allow us to try setting it again, causing InvalidStateError.
     Using done() prevents this.


### PR DESCRIPTION
## Fix: Use `.done()` instead of `.cancelled()` to prevent InvalidStateError

### Problem

The code was checking `if not ql.future.cancelled()` before setting results or exceptions on futures. However, a future can be in a "done" state for multiple reasons:
- Cancelled
- Has a result set
- Has an exception set

see: https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.done 

If a future already has a result or exception set (but is not cancelled), the `cancelled()` check would pass, and attempting to call `set_result()` or `set_exception()` on an already-done future would raise `InvalidStateError`.

### Solution

Changed all checks from `cancelled()` to `done()` in three locations:
1. `dispatch_queue_batch()` - when setting results/exceptions from batch load
2. `failed_dispatch()` - when setting exceptions after batch failure
3. `prime()` - when priming the cache with values

The `done()` check is more comprehensive as it catches all completion states, preventing `InvalidStateError` in all scenarios.

### Testing

All existing tests pass, and new tests verify that:
- Futures that are already done (with result or exception) are not overwritten
- No `InvalidStateError` exceptions are raised
- The behavior is correct in both success and failure scenarios