### PR TITLE
Use python 3.14 for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.13
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.14'
         cache: pip
     - name: Install dependencies
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,6 @@ test = ["coveralls", "hatch",  "mock", "pytest>=3.6", "pytest-asyncio", "pytest-
 [project.urls]
 "Homepage" = "https://github.com/syrusakbary/aiodataloader"
 
-[tool.black]
-target-version = ["py37", "py38", "py39", "py310", "py311", "py312", "py313", "py314"]
-
 [tool.hatch.envs.default.scripts]
 lint = "flake8 && black --check . && mypy"
 test = "pytest --cov=aiodataloader"


### PR DESCRIPTION
- update the release workflow to use python 3.14
- remove unnecessary black configuration